### PR TITLE
Make Node fields public and remove Node.Colour().

### DIFF
--- a/graphs/graphs.go
+++ b/graphs/graphs.go
@@ -56,7 +56,7 @@ func readNodes(r io.Reader) (map[uint64]*Node, error) {
 				return nil, errors.New("non-digit id on node")
 			}
 			edge := NewNode(e)
-			current.AddEdge(edge.id)
+			current.AddEdge(edge.Id)
 			nodes[e] = edge
 		}
 	}
@@ -71,7 +71,7 @@ func (g *Graph) Visit(id uint64) ([]uint64, error) {
 	}
 
 	ret := []uint64{}
-	ret = append(ret, n.edges...)
+	ret = append(ret, n.Edges...)
 	return ret, nil
 }
 

--- a/graphs/graphs_test.go
+++ b/graphs/graphs_test.go
@@ -8,49 +8,49 @@ import (
 
 var (
 	node42 = &Node{
-		id:     42,
-		colour: White,
-		edges:  nil,
+		Id:     42,
+		Colour: White,
+		Edges:  nil,
 	}
 	node42Grey = &Node{
-		id:     42,
-		colour: Grey,
-		edges:  nil,
+		Id:     42,
+		Colour: Grey,
+		Edges:  nil,
 	}
 	node42Black = &Node{
-		id:     42,
-		colour: Grey,
-		edges:  nil,
+		Id:     42,
+		Colour: Grey,
+		Edges:  nil,
 	}
 	node1 = &Node{
-		id:     1,
-		colour: White,
-		edges:  nil,
+		Id:     1,
+		Colour: White,
+		Edges:  nil,
 	}
 	node2 = &Node{
-		id:     2,
-		colour: White,
-		edges:  nil,
+		Id:     2,
+		Colour: White,
+		Edges:  nil,
 	}
 	node3 = &Node{
-		id:     3,
-		colour: White,
-		edges:  nil,
+		Id:     3,
+		Colour: White,
+		Edges:  nil,
 	}
 	node1_2 = &Node{
-		id:     1,
-		colour: White,
-		edges:  []uint64{node2.id},
+		Id:     1,
+		Colour: White,
+		Edges:  []uint64{node2.Id},
 	}
 	node2_3 = &Node{
-		id:     2,
-		colour: White,
-		edges:  []uint64{node3.id},
+		Id:     2,
+		Colour: White,
+		Edges:  []uint64{node3.Id},
 	}
 	node1_2_3 = &Node{
-		id:     1,
-		colour: White,
-		edges:  []uint64{node2.id, node3.id},
+		Id:     1,
+		Colour: White,
+		Edges:  []uint64{node2.Id, node3.Id},
 	}
 )
 
@@ -135,12 +135,12 @@ func TestNode_IncrementColour(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			n := &Node{
-				id:     tt.node.id,
-				colour: tt.node.colour,
-				edges:  tt.node.edges,
+				Id:     tt.node.Id,
+				Colour: tt.node.Colour,
+				Edges:  tt.node.Edges,
 			}
 			n.IncrementColour()
-			diff := cmp.Diff(tt.colour, n.colour, cmp.AllowUnexported(Graph{}, Node{}))
+			diff := cmp.Diff(tt.colour, n.Colour, cmp.AllowUnexported(Graph{}, Node{}))
 			if diff != "" {
 				t.Errorf(diff)
 			}

--- a/graphs/nodes.go
+++ b/graphs/nodes.go
@@ -12,24 +12,20 @@ const (
 
 // Node represents a node of a graph.
 type Node struct {
-	id     uint64
-	colour Colour
-	edges  []uint64
+	Id     uint64
+	Colour Colour
+	Edges  []uint64
 }
 
 // NewNode returns a pointer to a new Node with the given ID.
-func NewNode(id uint64) *Node { return &Node{id: id} }
-
-// Colour returns the Node's colour.
-func (n *Node) Colour() Colour { return n.colour }
+func NewNode(id uint64) *Node { return &Node{Id: id} }
 
 // IncrementColour sets the Colour of the Node one further closer to black. If it is black already, it does nothing.
 func (n *Node) IncrementColour() {
-	if n.colour != Black {
-		n.colour++
+	if n.Colour != Black {
+		n.Colour++
 	}
 }
 
 // AddEdge appends a Node to the list of Edges.
-func (n *Node) AddEdge(id uint64) { n.edges = append(n.edges, id) }
-
+func (n *Node) AddEdge(id uint64) { n.Edges = append(n.Edges, id) }


### PR DESCRIPTION
`Node` fields are now public so that they can be accessed from other
packages as needed. The `Node.Colour()` is no longer needed and therefor
removed.